### PR TITLE
Fix logging variable name in NFT card registration

### DIFF
--- a/cloudServer.py
+++ b/cloudServer.py
@@ -55,7 +55,7 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
                 data = parse.parse_qs(rfile_str, keep_blank_values=1)
                 card_uid = self.path.split('/')[-1]
                 LocalData.cards[card_uid] = data
-                print("Minted NFT at blockNumber %s: %s" % (record_id, data))
+                print("Registered NFT card %s: %s" % (card_uid, data))
                 # HTTP 200: ok
                 self.send_response(200)
             else:


### PR DESCRIPTION
## Summary
- fix incorrect variable in cloud server log when registering NFT card

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e34bb959c832880abc98af3f596b4